### PR TITLE
Speed up setting colours

### DIFF
--- a/ChromaPython/ChromaDatatypes.py
+++ b/ChromaPython/ChromaDatatypes.py
@@ -84,11 +84,11 @@ class ChromaColor:
                 self._green = (tmp >> 8) & 255
                 self._red = (tmp >> 16) & 255
             elif None not in (red, blue, green) and hexcolor is None:
-                if red not in range(0, 256):
+                if not 0 <= red <= 255:
                     raise ValueError('Red-value out of range!')
-                if green not in range(0, 256):
+                if not 0 <= green <= 255:
                     raise ValueError('Green-value out of range!')
-                if blue not in range(0, 256):
+                if not 0 <= blue <= 255:
                     raise ValueError('Blue-value out of range!')
                 self._blue = blue
                 self._red = red

--- a/ChromaPython/ChromaDatatypes.py
+++ b/ChromaPython/ChromaDatatypes.py
@@ -71,7 +71,7 @@ class ChromaColor:
 
     def set(self, red=None, green=None, blue=None, hexcolor=None):
         try:
-            if None in (red, blue, green) and hexcolor is not None:
+            if hexcolor is not None:
                 if hexcolor[0] == '#':
                     color = hexcolor[1:]
                 elif hexcolor[0] == '0' and hexcolor[1] == 'x':
@@ -83,16 +83,16 @@ class ChromaColor:
                 self._blue = tmp & 255
                 self._green = (tmp >> 8) & 255
                 self._red = (tmp >> 16) & 255
-            elif None not in (red, blue, green) and hexcolor is None:
+            elif None not in (red, blue, green):
                 if not 0 <= red <= 255:
                     raise ValueError('Red-value out of range!')
                 if not 0 <= green <= 255:
                     raise ValueError('Green-value out of range!')
                 if not 0 <= blue <= 255:
                     raise ValueError('Blue-value out of range!')
-                self._blue = blue
-                self._red = red
-                self._green = green
+                self._red = int(red)
+                self._green = int(green)
+                self._blue = int(blue)
                 return True
         except:
             # TODO Add proper exception handling

--- a/ChromaPython/ChromaDatatypes.py
+++ b/ChromaPython/ChromaDatatypes.py
@@ -71,7 +71,20 @@ class ChromaColor:
 
     def set(self, red=None, green=None, blue=None, hexcolor=None):
         try:
-            if hexcolor is not None:
+            if None not in (red, blue, green):
+                if not 0 <= red <= 255:
+                    raise ValueError('Red-value out of range!')
+                if not 0 <= green <= 255:
+                    raise ValueError('Green-value out of range!')
+                if not 0 <= blue <= 255:
+                    raise ValueError('Blue-value out of range!')
+                    
+                self._red = int(red)
+                self._green = int(green)
+                self._blue = int(blue)
+                return True
+                
+            elif hexcolor is not None:
                 if hexcolor[0] == '#':
                     color = hexcolor[1:]
                 elif hexcolor[0] == '0' and hexcolor[1] == 'x':
@@ -83,16 +96,6 @@ class ChromaColor:
                 self._blue = tmp & 255
                 self._green = (tmp >> 8) & 255
                 self._red = (tmp >> 16) & 255
-            elif None not in (red, blue, green):
-                if not 0 <= red <= 255:
-                    raise ValueError('Red-value out of range!')
-                if not 0 <= green <= 255:
-                    raise ValueError('Green-value out of range!')
-                if not 0 <= blue <= 255:
-                    raise ValueError('Blue-value out of range!')
-                self._red = int(red)
-                self._green = int(green)
-                self._blue = int(blue)
                 return True
         except:
             # TODO Add proper exception handling


### PR DESCRIPTION
Hi, I noticed that setting the colour slowed down the code quite considerably. It turned out it's because you're calling `range(256)` multiple times each time a colour is set, so I made a quick swap to use `0 <= colour <= 255`, and it fixed the speed issue :)

I also just tweaked the if statements a little, so it'll use RGB even if a hex code is set, or use a hex code if only 1 or 2 of the colours are set.